### PR TITLE
build: add new spec file for one-directory distribution

### DIFF
--- a/src/build_win64_onedir.spec
+++ b/src/build_win64_onedir.spec
@@ -1,0 +1,50 @@
+# -*- mode: python ; coding: utf-8 -*-
+import os
+from glob import glob
+
+a = Analysis(
+    ['Final.py'],
+    pathex=[os.getcwd()],
+    binaries=[],
+    datas=[
+        (os.path.join(os.getcwd(), 'src', 'Resources'), 'Resources'),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe_windows = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='Elden_Ring_Save_Editor',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe_windows,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Elden_Ring_Save_Editor_WIN64'
+)


### PR DESCRIPTION
- Created 'build_win64_ondir.spec' to support standalone directory builds.
- Optimized for faster application startup by avoiding self-extraction.
- Kept the original 'build.spec' intact for one-file portable releases.
- Provides users with a choice between a single executable and a high-performance folder version.