### PR TITLE
fix: parse loadout after relic replacement

### DIFF
--- a/src/vessel_handler.py
+++ b/src/vessel_handler.py
@@ -766,6 +766,7 @@ class LoadoutHandler:
             if self.heroes[hero_type].cur_vessel_id == vessel_id:
                 self.heroes[hero_type].auto_adjust_cur_equipment()
             self.update_hero_loadout(hero_type)
+            self.parse()
 
     def replace_preset_relic(self, hero_type: int, relic_index: int, new_relic_ga,
                              hero_preset_index: int = -1, preset_index: int = -1):


### PR DESCRIPTION
        if new_relic_ga != 0:
            self.inventory.equip_relic(new_relic_ga, hero_type)

this triggers `.update_entry_data` then `.parse`, which results in all relic entries being inited with empty `.equipped_by`