### PR TITLE
feat: Add batch add relic functionality

### DIFF
--- a/src/Final.py
+++ b/src/Final.py
@@ -4509,6 +4509,15 @@ class SaveEditorGUI:
         lang_mgr.register(btn_add_relic, N_("➕ Add Relic"))
         btn_add_relic.pack(side="left", padx=5)
 
+        btn_batch_add = ttk.Button(
+            controls_frame,
+            text="➕ Batch Add Relic",
+            style="Add.TButton",
+            command=self.batch_add_relic_tk,
+        )
+        lang_mgr.register(btn_batch_add, N_("➕ Batch Add Relic"))
+        btn_batch_add.pack(side="left", padx=5)
+
         btn_refresh = ttk.Button(
             controls_frame, text="🔄 Refresh Inventory", command=self.reload_inventory
         )
@@ -6164,6 +6173,26 @@ class SaveEditorGUI:
                 self.modify_selected_relic()
         except Exception as e:
             messagebox.showerror("Error", f"Failed to add relic: {e}")
+
+    def batch_add_relic_tk(self):
+        if globals.data is None:
+            messagebox.showwarning(
+                "Warning", "No save file loaded. Please open a save file first."
+            )
+            return
+        dialog = BatchAddRelicDialog(self.root)
+        if not dialog.result:
+            return
+        try:
+            added_count, added_gas = self.inventory_handler.batch_add_relics(
+                count=dialog.result,
+                relic_type=dialog.relic_type
+            )
+            if added_count > 0:
+                msg_info("Success", f"Successfully added {added_count} relics. Refreshing inventory.")
+                self.refresh_inventory_and_vessels()
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to batch add relics: {e}")
 
     def _find_valid_relic_id_for_effects(self, current_id, effects):
         """Find a valid relic ID that can have the given effects (must be same color)"""
@@ -8319,6 +8348,100 @@ class SearchDialog:
 
 import tkinter as tk
 from tkinter import ttk
+
+
+class BatchAddRelicDialog(tk.Toplevel):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.title("Batch Add Relics")
+        self.result = None
+        self.relic_type = None
+        self.resizable(False, False)
+
+        main_frame = ttk.Frame(self, padding="10 10 10 10")
+        main_frame.pack(fill=tk.BOTH, expand=True)
+
+        ttk.Label(
+            main_frame,
+            text="Select relic type and number to add.\nNote: Type cannot be changed later.",
+            justify=tk.CENTER,
+        ).pack(pady=10)
+
+        type_frame = ttk.Frame(main_frame)
+        type_frame.pack(pady=10)
+        ttk.Label(type_frame, text="Relic Type:").pack(side=tk.LEFT, padx=5)
+        self.type_var = tk.StringVar(value="normal")
+        ttk.Radiobutton(
+            type_frame,
+            text="Normal",
+            variable=self.type_var,
+            value="normal"
+        ).pack(side=tk.LEFT, padx=5)
+        ttk.Radiobutton(
+            type_frame,
+            text="Deep",
+            variable=self.type_var,
+            value="deep"
+        ).pack(side=tk.LEFT, padx=5)
+
+        count_frame = ttk.Frame(main_frame)
+        count_frame.pack(pady=10)
+        ttk.Label(count_frame, text="Number to Add:").pack(side=tk.LEFT, padx=5)
+        self.count_var = tk.IntVar(value=10)
+        count_spinbox = ttk.Spinbox(
+            count_frame,
+            from_=1,
+            to=1000,
+            textvariable=self.count_var,
+            width=10
+        )
+        count_spinbox.pack(side=tk.LEFT, padx=5)
+
+        btn_frame = ttk.Frame(main_frame)
+        btn_frame.pack(pady=10)
+        ttk.Button(
+            btn_frame,
+            text="OK",
+            command=self.on_ok,
+            style="Add.TButton"
+        ).pack(side=tk.LEFT, padx=5)
+        ttk.Button(
+            btn_frame,
+            text="Cancel",
+            command=lambda: self.set_result(None)
+        ).pack(side=tk.LEFT, padx=5)
+
+        self.protocol("WM_DELETE_WINDOW", lambda: self.set_result(None))
+        self.center_window(parent)
+        self.focus_force()
+        self.transient(parent)
+        self.grab_set()
+        self.wait_window(self)
+
+    def center_window(self, parent):
+        self.update_idletasks()
+        w = self.winfo_width()
+        h = self.winfo_height()
+        parent_w = parent.winfo_width()
+        parent_h = parent.winfo_height()
+        parent_x = parent.winfo_x()
+        parent_y = parent.winfo_y()
+        x = parent_x + (parent_w // 2) - (w // 2)
+        y = parent_y + (parent_h // 2) - (h // 2)
+        self.geometry(f"+{x}+{y}")
+
+    def on_ok(self):
+        count = self.count_var.get()
+        if count < 1:
+            messagebox.showwarning("Warning", "Please enter a valid number greater than 0.")
+            return
+        self.relic_type = self.type_var.get()
+        self.result = count
+        self.destroy()
+
+    def set_result(self, value):
+        self.result = value
+        self.destroy()
 
 
 class RelicTypeSelector(tk.Toplevel):

--- a/src/Resources/locales/en_US/LC_MESSAGES/en_US.po
+++ b/src/Resources/locales/en_US/LC_MESSAGES/en_US.po
@@ -162,6 +162,10 @@ msgstr "No saved presets for this character"
 msgid "➕ Add Relic"
 msgstr "➕ Add Relic"
 
+#: Final.py:4518
+msgid "➕ Batch Add Relic"
+msgstr "➕ Batch Add Relic"
+
 #: Final.py:4515
 msgid "🔄 Refresh Inventory"
 msgstr "🔄 Refresh Inventory"

--- a/src/Resources/locales/zh_CN/LC_MESSAGES/zh_CN.po
+++ b/src/Resources/locales/zh_CN/LC_MESSAGES/zh_CN.po
@@ -160,6 +160,10 @@ msgstr "此角色暂未添加任何预设方案"
 msgid "➕ Add Relic"
 msgstr "➕ 新增遗物"
 
+#: Final.py:4518
+msgid "➕ Batch Add Relic"
+msgstr "➕ 批量新增遗物"
+
 #: Final.py:4515
 msgid "🔄 Refresh Inventory"
 msgstr "🔄 刷新库存"

--- a/src/Resources/locales/zh_TW/LC_MESSAGES/zh_TW.po
+++ b/src/Resources/locales/zh_TW/LC_MESSAGES/zh_TW.po
@@ -162,6 +162,10 @@ msgstr "此角色還沒有設定任何預置配裝"
 msgid "➕ Add Relic"
 msgstr "➕ 新增遺物"
 
+#: Final.py:4518
+msgid "➕ Batch Add Relic"
+msgstr "➕ 批量新增遺物"
+
 #: Final.py:4515
 msgid "🔄 Refresh Inventory"
 msgstr "🔄 重新整理物品欄"

--- a/src/inventory_handler.py
+++ b/src/inventory_handler.py
@@ -614,6 +614,28 @@ class InventoryHandler:
             self.parse()  # Just make sure everything is fine
             return True, self.entries[empty_entry_index].ga_handle
 
+    def batch_add_relics(self, count: int, relic_type: str = "normal", update_progress=None):
+        with self._lock:
+            logger.info(f"Batch adding {count} {relic_type} relics")
+            added_gas = []
+            failed_count = 0
+
+            for i in range(count):
+                try:
+                    success, ga = self.add_relic_to_inventory(relic_type=relic_type)
+                    if success:
+                        added_gas.append(ga)
+                    if update_progress:
+                        update_progress(int((i + 1) / count * 100), f"Added {i + 1}/{count} relics...")
+                except Exception as e:
+                    logger.error(f"Failed to add relic {i + 1}: {e}")
+                    failed_count += 1
+                    if failed_count > 5:  # Stop after too many failures
+                        break
+
+            logger.info(f"Batch add complete. Added {len(added_gas)}, failed {failed_count}")
+            return len(added_gas), added_gas
+
     def remove_relic_from_inventory(self, ga_handel):
         with self._lock:
             logger.info("Removing relic from inventory")

--- a/src/vessel_handler.py
+++ b/src/vessel_handler.py
@@ -191,7 +191,7 @@ class HeroLoadout:
         result_msgs = []
         for idx, im_v in enumerate(im_vessels):
             if idx not in vessel_indices:
-                result_msgs.append(f"{game_data.vessels[im_v["vessel_id"]].name} skipped.")
+                result_msgs.append(f"{game_data.vessels[im_v['vessel_id']].name} skipped.")
                 continue
             for v in self.vessels:
                 if v["vessel_id"] == im_v["vessel_id"]:


### PR DESCRIPTION
Problem Solved / Feature Added:
Added a batch add relic feature to the Elden Ring Nightreign Save Editor, allowing users to add multiple relics at once, significantly improving editing efficiency.

Implementation (Core Logic):
1. Added `batch_add_relics()` method in `inventory_handler.py` that implements batch addition by looping through the existing `add_relic_to_inventory()` method, supporting specified count (1-1000) and relic type (normal/deep)
2. Added "➕ Batch Add Relic" button in the relics tab of `Final.py` and implemented `batch_add_relic_tk()` method to handle batch addition logic
3. Created `BatchAddRelicDialog` dialog class providing a user-friendly interface with type selection and count input functionality
4. Updated translation files for three languages (en_US, zh_CN, zh_TW) with translations for the new feature
5. Fixed f-string syntax error in `vessel_handler.py:194`

Testing:
- Program starts normally without syntax errors
- All game parameter files load successfully