### PR TITLE
fix: vessel parser

### DIFF
--- a/src/vessel_handler.py
+++ b/src/vessel_handler.py
@@ -331,8 +331,9 @@ class VesselParser:
         while cursor < len(globals.data):
             p_start = cursor
             header = struct.unpack_from("<B", globals.data, cursor)[0]
-            if header != 0x01:
-                break
+            if header != 0x01:  # Removed preset
+                cursor += 80  # Skip the rest of this preset block
+                continue
 
             # Offsets for custom preset fields
             p_offsets = {


### PR DESCRIPTION
- fix #114 
- fixed an​ issue where removing​ a preset in-game would cause the vessel data parsing to break prematurely

I tried to create some new presets in-game based on the preset that has the issue. The unknown byte "6E" in the new​ presets is "00", even though those presets appear exactly the same. So idk what the byte indicates but it seems to work properly in-game.